### PR TITLE
Category links now correctly render relevant articles.

### DIFF
--- a/client/src/components/Categories/index.js
+++ b/client/src/components/Categories/index.js
@@ -12,7 +12,6 @@ function Categories({ setArticles }) {
   function handleClick(e) {
     api.getArticleCategoriesSingle(e.target.text)
       .then(result => {
-        console.log(result);
         setArticles(result.data.map( item => ({
           title: item.title,
           image: item.image,

--- a/controllers/articlesController.js
+++ b/controllers/articlesController.js
@@ -38,7 +38,7 @@ module.exports = {
   },
   findByCategorySingle: function(req, res) {
     db.Article
-      .find({category: [req.params.category]})
+      .find({category: req.params.category})
       .then(dbModel => res.json(dbModel))
       .catch(err => res.status(422).json(err))
   },


### PR DESCRIPTION
Changed findByCategorySingle in articlesController to look for an array containing the passed in category, not an exact match of an array with the single specified category.